### PR TITLE
test: add widget module jsdom coverage suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^22.10.2",
         "@vitest/coverage-v8": "^2.1.9",
         "ethers": "^6.16.0",
+        "jsdom": "^29.0.2",
         "tsup": "^8.3.5",
         "typescript": "^5.7.2",
         "vitest": "^2.1.8"
@@ -50,6 +51,45 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -107,6 +147,159 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -2834,6 +3027,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3417,6 +3620,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3447,6 +3678,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3560,6 +3798,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -4566,6 +4817,52 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer/node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4757,6 +5054,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -4944,6 +5248,100 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/jsonfile": {
@@ -5206,6 +5604,13 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -5772,6 +6177,19 @@
       "dev": true,
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -6002,6 +6420,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6213,6 +6641,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
@@ -6647,6 +7088,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -6840,6 +7288,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -6889,6 +7357,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -7774,6 +8268,87 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7986,6 +8561,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/node": "^22.10.2",
     "@vitest/coverage-v8": "^2.1.9",
     "ethers": "^6.16.0",
+    "jsdom": "^29.0.2",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/test/widgets-bridge.test.ts
+++ b/test/widgets-bridge.test.ts
@@ -47,7 +47,6 @@ function validSigningMessage(overrides: Record<string, unknown> = {}) {
 describe("widgets/bridge", () => {
   let iframe: HTMLIFrameElement;
   let source: { postMessage: ReturnType<typeof vi.fn> };
-  let messageHandler: ((event: MessageEvent) => void | Promise<void>) | undefined;
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -75,26 +74,20 @@ describe("widgets/bridge", () => {
       configurable: true,
       value: source,
     });
-
-    vi.spyOn(window, "addEventListener").mockImplementation(
-      (type: string, listener: EventListenerOrEventListenerObject) => {
-        if (type === "message" && typeof listener === "function") {
-          messageHandler = listener as (event: MessageEvent) => void | Promise<void>;
-        }
-      }
-    );
   });
 
   async function dispatchMessage(
     data: Record<string, unknown>,
     options: { origin?: string; eventSource?: unknown } = {}
   ) {
-    const event = {
+    const event = new MessageEvent("message", {
       data,
       origin: options.origin ?? "https://widget.omatrust.org",
-      source: options.eventSource ?? source,
-    } as MessageEvent;
-    await messageHandler?.(event);
+      source: (options.eventSource ?? source) as WindowProxy,
+    });
+    window.dispatchEvent(event);
+    // Allow async bridge handlers (including delayed signer mocks) to settle.
+    await new Promise(resolve => setTimeout(resolve, 25));
   }
 
   it("responds to handshake with hostReady", async () => {
@@ -249,6 +242,34 @@ describe("widgets/bridge", () => {
 
     await dispatchMessage(
       validSigningMessage({
+        id: 123,
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        id: 123,
+        error: expect.stringContaining("Missing or invalid request id"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    await dispatchMessage(
+      validSigningMessage({
+        domain: null,
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        id: "req-1",
+        error: expect.stringContaining("Missing domain object"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    await dispatchMessage(
+      validSigningMessage({
         domain: {
           name: "BAD",
           version: "1.4.0",
@@ -266,6 +287,61 @@ describe("widgets/bridge", () => {
       }),
       "https://widget.omatrust.org"
     );
+
+    await dispatchMessage(
+      validSigningMessage({
+        domain: {
+          name: "EAS",
+          version: "0.0.0",
+          chainId: 66238,
+          verifyingContract: allowedContract,
+        },
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Unexpected domain version"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    await dispatchMessage(
+      validSigningMessage({
+        domain: {
+          name: "EAS",
+          version: "1.4.0",
+          chainId: 0,
+          verifyingContract: allowedContract,
+        },
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Invalid domain chainId"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    await dispatchMessage(
+      validSigningMessage({
+        domain: {
+          name: "EAS",
+          version: "1.4.0",
+          chainId: 66238,
+          verifyingContract: "0x1234",
+        },
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Invalid verifyingContract"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
     bridge.destroy();
   });
 
@@ -331,6 +407,41 @@ describe("widgets/bridge", () => {
       expect.objectContaining({
         type: OMATRUST_SIGNATURE_ERROR,
         error: expect.stringContaining("Invalid attester address"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    bridge.destroy();
+  });
+
+  it("rejects missing types and message objects", async () => {
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn(),
+    });
+
+    await dispatchMessage(
+      validSigningMessage({
+        types: null,
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Missing types object"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    await dispatchMessage(
+      validSigningMessage({
+        message: null,
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Missing message object"),
       }),
       "https://widget.omatrust.org"
     );
@@ -459,7 +570,7 @@ describe("widgets/bridge", () => {
   });
 
   it("destroy removes the message listener", async () => {
-    const removeSpy = vi.spyOn(window, "removeEventListener").mockImplementation(() => {});
+    const removeSpy = vi.spyOn(window, "removeEventListener");
     const bridge = await createSigningBridge({
       iframeId: "widget-frame",
       signTypedData: vi.fn(),

--- a/test/widgets-bridge.test.ts
+++ b/test/widgets-bridge.test.ts
@@ -83,7 +83,9 @@ describe("widgets/bridge", () => {
     const event = new MessageEvent("message", {
       data,
       origin: options.origin ?? "https://widget.omatrust.org",
-      source: (options.eventSource ?? source) as WindowProxy,
+    });
+    Object.defineProperty(event, "source", {
+      value: options.eventSource ?? source,
     });
     window.dispatchEvent(event);
     // Allow async bridge handlers (including delayed signer mocks) to settle.

--- a/test/widgets-bridge.test.ts
+++ b/test/widgets-bridge.test.ts
@@ -1,0 +1,490 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OMATRUST_HOST_READY,
+  OMATRUST_READY,
+  OMATRUST_SIGNATURE,
+  OMATRUST_SIGNATURE_ERROR,
+  OMATRUST_SIGN_TYPED_DATA,
+} from "../src/widgets/protocol";
+import { createSigningBridge } from "../src/widgets/bridge";
+
+const { mockFetchTrustPolicy, mockExtractAllowlists } = vi.hoisted(() => ({
+  mockFetchTrustPolicy: vi.fn(),
+  mockExtractAllowlists: vi.fn(),
+}));
+
+vi.mock("../src/widgets/trust-policy", () => ({
+  TRUST_POLICY_URL: "https://api.omatrust.org/v1/trust-policy",
+  fetchTrustPolicy: mockFetchTrustPolicy,
+  extractAllowlists: mockExtractAllowlists,
+}));
+
+const allowedContract = "0x1234567890abcdef1234567890abcdef12345678";
+const allowedSchema = `0x${"a".repeat(64)}`;
+const attester = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+
+function validSigningMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    type: OMATRUST_SIGN_TYPED_DATA,
+    id: "req-1",
+    domain: {
+      name: "EAS",
+      version: "1.4.0",
+      chainId: 66238,
+      verifyingContract: allowedContract,
+    },
+    types: { Attest: [{ name: "schema", type: "bytes32" }] },
+    message: {
+      schema: allowedSchema,
+      attester,
+      deadline: Math.floor(Date.now() / 1000) + 600,
+    },
+    ...overrides,
+  };
+}
+
+describe("widgets/bridge", () => {
+  let iframe: HTMLIFrameElement;
+  let source: { postMessage: ReturnType<typeof vi.fn> };
+  let messageHandler: ((event: MessageEvent) => void | Promise<void>) | undefined;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+
+    mockFetchTrustPolicy.mockResolvedValue({
+      version: 1,
+      updatedAt: "2026-04-13T00:00:00Z",
+      widgetOrigins: [],
+      chains: {},
+    });
+    mockExtractAllowlists.mockReturnValue({
+      allowedContracts: [allowedContract],
+      allowedSchemas: [allowedSchema],
+    });
+
+    document.body.innerHTML = "";
+    iframe = document.createElement("iframe");
+    iframe.id = "widget-frame";
+    iframe.src = "https://widget.omatrust.org/embed";
+    document.body.appendChild(iframe);
+
+    source = { postMessage: vi.fn() };
+    Object.defineProperty(iframe, "contentWindow", {
+      configurable: true,
+      value: source,
+    });
+
+    vi.spyOn(window, "addEventListener").mockImplementation(
+      (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === "message" && typeof listener === "function") {
+          messageHandler = listener as (event: MessageEvent) => void | Promise<void>;
+        }
+      }
+    );
+  });
+
+  async function dispatchMessage(
+    data: Record<string, unknown>,
+    options: { origin?: string; eventSource?: unknown } = {}
+  ) {
+    const event = {
+      data,
+      origin: options.origin ?? "https://widget.omatrust.org",
+      source: options.eventSource ?? source,
+    } as MessageEvent;
+    await messageHandler?.(event);
+  }
+
+  it("responds to handshake with hostReady", async () => {
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn(),
+    });
+
+    await dispatchMessage({ type: OMATRUST_READY });
+
+    expect(source.postMessage).toHaveBeenCalledWith({ type: OMATRUST_HOST_READY }, "https://widget.omatrust.org");
+    bridge.destroy();
+  });
+
+  it("signs valid request and returns signature", async () => {
+    const signTypedData = vi.fn().mockResolvedValue("0xsigned");
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData,
+    });
+
+    const request = validSigningMessage();
+    await dispatchMessage(request);
+
+    expect(signTypedData).toHaveBeenCalledWith(request.domain, request.types, request.message);
+    expect(source.postMessage).toHaveBeenCalledWith(
+      { type: OMATRUST_SIGNATURE, id: "req-1", signature: "0xsigned" },
+      "https://widget.omatrust.org"
+    );
+    bridge.destroy();
+  });
+
+  it("returns signatureError when signer throws", async () => {
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn().mockRejectedValue(new Error("wallet failed")),
+    });
+
+    await dispatchMessage(validSigningMessage());
+
+    expect(source.postMessage).toHaveBeenCalledWith(
+      { type: OMATRUST_SIGNATURE_ERROR, id: "req-1", error: "wallet failed" },
+      "https://widget.omatrust.org"
+    );
+    bridge.destroy();
+  });
+
+  it("ignores messages from untrusted origins unless override matches", async () => {
+    const signTypedData = vi.fn();
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData,
+    });
+
+    await dispatchMessage(validSigningMessage(), { origin: "https://evil.example.com" });
+    expect(signTypedData).not.toHaveBeenCalled();
+    expect(source.postMessage).not.toHaveBeenCalled();
+
+    const bridgeWithOverride = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData,
+      devOriginOverride: "http://localhost:3000",
+    });
+    await dispatchMessage(validSigningMessage(), { origin: "http://localhost:3000" });
+    expect(signTypedData).toHaveBeenCalledTimes(1);
+
+    bridge.destroy();
+    bridgeWithOverride.destroy();
+  });
+
+  it("ignores messages from wrong source window", async () => {
+    const signTypedData = vi.fn();
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData,
+    });
+
+    await dispatchMessage(validSigningMessage(), {
+      eventSource: { postMessage: vi.fn() },
+    });
+
+    expect(signTypedData).not.toHaveBeenCalled();
+    expect(source.postMessage).not.toHaveBeenCalled();
+    bridge.destroy();
+  });
+
+  it("ignores malformed and non-omatrust messages", async () => {
+    const signTypedData = vi.fn();
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData,
+    });
+
+    await dispatchMessage({ type: "other:event" });
+    await dispatchMessage({ foo: "bar" });
+
+    expect(signTypedData).not.toHaveBeenCalled();
+    expect(source.postMessage).not.toHaveBeenCalled();
+    bridge.destroy();
+  });
+
+  it("ignores message when iframe cannot be resolved", async () => {
+    const signTypedData = vi.fn();
+    const bridge = await createSigningBridge({
+      iframeId: "missing-frame",
+      signTypedData,
+    });
+
+    await dispatchMessage(validSigningMessage());
+    expect(signTypedData).not.toHaveBeenCalled();
+    expect(source.postMessage).not.toHaveBeenCalled();
+    bridge.destroy();
+  });
+
+  it("resolves iframe lazily and works after iframe remount", async () => {
+    const signTypedData = vi.fn().mockResolvedValue("0xremounted");
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData,
+    });
+
+    const oldSource = source;
+    const replacementIframe = document.createElement("iframe");
+    replacementIframe.id = "widget-frame";
+    replacementIframe.src = "https://widget.omatrust.org/new";
+    const newSource = { postMessage: vi.fn() };
+    Object.defineProperty(replacementIframe, "contentWindow", {
+      configurable: true,
+      value: newSource,
+    });
+    iframe.replaceWith(replacementIframe);
+
+    await dispatchMessage(validSigningMessage(), { eventSource: oldSource });
+    expect(signTypedData).not.toHaveBeenCalled();
+
+    await dispatchMessage(validSigningMessage({ id: "req-remount" }), {
+      eventSource: newSource,
+    });
+    expect(signTypedData).toHaveBeenCalledTimes(1);
+    expect(newSource.postMessage).toHaveBeenCalledWith(
+      { type: OMATRUST_SIGNATURE, id: "req-remount", signature: "0xremounted" },
+      "https://widget.omatrust.org"
+    );
+    bridge.destroy();
+  });
+
+  it("rejects invalid EAS data with descriptive error", async () => {
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn(),
+    });
+
+    await dispatchMessage(
+      validSigningMessage({
+        domain: {
+          name: "BAD",
+          version: "1.4.0",
+          chainId: 66238,
+          verifyingContract: allowedContract,
+        },
+      })
+    );
+
+    expect(source.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        id: "req-1",
+        error: expect.stringContaining("Signing request rejected"),
+      }),
+      "https://widget.omatrust.org"
+    );
+    bridge.destroy();
+  });
+
+  it("rejects non-positive deadlines", async () => {
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn(),
+    });
+
+    await dispatchMessage(
+      validSigningMessage({
+        message: {
+          schema: allowedSchema,
+          attester,
+          deadline: 0,
+        },
+      })
+    );
+
+    expect(source.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Invalid deadline"),
+      }),
+      "https://widget.omatrust.org"
+    );
+    bridge.destroy();
+  });
+
+  it("rejects invalid schema UID and attester", async () => {
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn(),
+    });
+
+    await dispatchMessage(
+      validSigningMessage({
+        message: {
+          schema: "0x1234",
+          attester,
+          deadline: Math.floor(Date.now() / 1000) + 600,
+        },
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Invalid schema UID"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    await dispatchMessage(
+      validSigningMessage({
+        message: {
+          schema: allowedSchema,
+          attester: "0x1234",
+          deadline: Math.floor(Date.now() / 1000) + 600,
+        },
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Invalid attester address"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    bridge.destroy();
+  });
+
+  it("rejects contract, schema and expired deadline not in policy", async () => {
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn(),
+    });
+
+    await dispatchMessage(
+      validSigningMessage({
+        domain: {
+          name: "EAS",
+          version: "1.4.0",
+          chainId: 66238,
+          verifyingContract: "0x9999999999999999999999999999999999999999",
+        },
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("not in the OMA3 trust policy"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    await dispatchMessage(
+      validSigningMessage({
+        message: {
+          schema: `0x${"b".repeat(64)}`,
+          attester,
+          deadline: Math.floor(Date.now() / 1000) + 600,
+        },
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Schema"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    await dispatchMessage(
+      validSigningMessage({
+        message: {
+          schema: allowedSchema,
+          attester,
+          deadline: Math.floor(Date.now() / 1000) - 1,
+        },
+      })
+    );
+    expect(source.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: OMATRUST_SIGNATURE_ERROR,
+        error: expect.stringContaining("Deadline has passed"),
+      }),
+      "https://widget.omatrust.org"
+    );
+
+    bridge.destroy();
+  });
+
+  it("handles concurrent signing requests with correlated ids", async () => {
+    const delayedSigner = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise<string>(resolve => setTimeout(() => resolve("0xfirst"), 20))
+      )
+      .mockResolvedValueOnce("0xsecond");
+
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: delayedSigner,
+    });
+
+    await Promise.all([
+      dispatchMessage(validSigningMessage({ id: "req-a" })),
+      dispatchMessage(validSigningMessage({ id: "req-b" })),
+    ]);
+
+    expect(delayedSigner).toHaveBeenCalledTimes(2);
+    expect(source.postMessage).toHaveBeenCalledWith(
+      { type: OMATRUST_SIGNATURE, id: "req-a", signature: "0xfirst" },
+      "https://widget.omatrust.org"
+    );
+    expect(source.postMessage).toHaveBeenCalledWith(
+      { type: OMATRUST_SIGNATURE, id: "req-b", signature: "0xsecond" },
+      "https://widget.omatrust.org"
+    );
+    bridge.destroy();
+  });
+
+  it("throws when trust policy fetch fails or allowlists are empty", async () => {
+    mockFetchTrustPolicy.mockRejectedValueOnce(new Error("policy unavailable"));
+
+    await expect(
+      createSigningBridge({
+        iframeId: "widget-frame",
+        signTypedData: vi.fn(),
+      })
+    ).rejects.toThrow("policy unavailable");
+
+    mockFetchTrustPolicy.mockResolvedValueOnce({
+      version: 1,
+      updatedAt: "2026-04-13T00:00:00Z",
+      widgetOrigins: [],
+      chains: {},
+    });
+    mockExtractAllowlists.mockReturnValueOnce({
+      allowedContracts: [],
+      allowedSchemas: [],
+    });
+
+    await expect(
+      createSigningBridge({
+        iframeId: "widget-frame",
+        signTypedData: vi.fn(),
+      })
+    ).rejects.toThrow("Trust policy contains no allowed contracts or schemas");
+  });
+
+  it("destroy removes the message listener", async () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener").mockImplementation(() => {});
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn(),
+    });
+
+    bridge.destroy();
+
+    expect(removeSpy).toHaveBeenCalledWith("message", expect.any(Function));
+  });
+
+  it("falls back to wildcard reply origin when iframe src cannot be parsed", async () => {
+    Object.defineProperty(iframe, "src", {
+      configurable: true,
+      get() {
+        throw new Error("bad iframe src");
+      },
+    });
+
+    const bridge = await createSigningBridge({
+      iframeId: "widget-frame",
+      signTypedData: vi.fn(),
+    });
+
+    await dispatchMessage({ type: OMATRUST_READY });
+    expect(source.postMessage).toHaveBeenCalledWith({ type: OMATRUST_HOST_READY }, "*");
+    bridge.destroy();
+  });
+});

--- a/test/widgets-index.test.ts
+++ b/test/widgets-index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import * as widgets from "../src/widgets";
+
+describe("widgets/index", () => {
+  it("re-exports widget bridge, policy and protocol symbols", () => {
+    expect(typeof widgets.createSigningBridge).toBe("function");
+    expect(typeof widgets.fetchTrustPolicy).toBe("function");
+    expect(typeof widgets.extractAllowlists).toBe("function");
+    expect(widgets.OMATRUST_READY).toBe("omatrust:ready");
+    expect(widgets.OMATRUST_SIGNATURE_ERROR).toBe("omatrust:signatureError");
+  });
+});

--- a/test/widgets-protocol.test.ts
+++ b/test/widgets-protocol.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  OMATRUST_HOST_READY,
+  OMATRUST_READY,
+  OMATRUST_SIGNATURE,
+  OMATRUST_SIGNATURE_ERROR,
+  OMATRUST_SIGN_TYPED_DATA,
+} from "../src/widgets/protocol";
+
+describe("widgets/protocol", () => {
+  it("exports canonical omatrust message type constants", () => {
+    expect(OMATRUST_READY).toBe("omatrust:ready");
+    expect(OMATRUST_HOST_READY).toBe("omatrust:hostReady");
+    expect(OMATRUST_SIGN_TYPED_DATA).toBe("omatrust:signTypedData");
+    expect(OMATRUST_SIGNATURE).toBe("omatrust:signature");
+    expect(OMATRUST_SIGNATURE_ERROR).toBe("omatrust:signatureError");
+  });
+
+  it("keeps all protocol constants in omatrust namespace", () => {
+    const types = [
+      OMATRUST_READY,
+      OMATRUST_HOST_READY,
+      OMATRUST_SIGN_TYPED_DATA,
+      OMATRUST_SIGNATURE,
+      OMATRUST_SIGNATURE_ERROR,
+    ];
+
+    for (const t of types) {
+      expect(t.startsWith("omatrust:")).toBe(true);
+    }
+    expect(new Set(types).size).toBe(types.length);
+  });
+});

--- a/test/widgets-trust-policy.test.ts
+++ b/test/widgets-trust-policy.test.ts
@@ -101,6 +101,7 @@ describe("widgets/trust-policy", () => {
   });
 
   it("extractAllowlists returns deduplicated contracts and schemas", async () => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
     vi.resetModules();
     const mod = await import("../src/widgets/trust-policy");
 

--- a/test/widgets-trust-policy.test.ts
+++ b/test/widgets-trust-policy.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPolicy = {
+  version: 1,
+  updatedAt: "2026-04-13T00:00:00Z",
+  widgetOrigins: ["https://widget.example.com"],
+  chains: {
+    "1": {
+      name: "Mainnet",
+      easContract: "0x1234567890abcdef1234567890abcdef12345678",
+      schemas: [`0x${"a".repeat(64)}`, `0x${"b".repeat(64)}`],
+    },
+    "10": {
+      name: "Optimism",
+      easContract: "0x1234567890abcdef1234567890abcdef12345678",
+      schemas: [`0x${"b".repeat(64)}`, `0x${"c".repeat(64)}`],
+    },
+  },
+};
+
+describe("widgets/trust-policy", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("fetches trust policy and caches it", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockPolicy,
+    } as Response);
+
+    vi.resetModules();
+    const mod = await import("../src/widgets/trust-policy");
+
+    const first = await mod.fetchTrustPolicy();
+    const second = await mod.fetchTrustPolicy();
+
+    expect(first).toEqual(mockPolicy);
+    expect(second).toEqual(mockPolicy);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when fetch returns non-ok response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+    } as Response);
+
+    vi.resetModules();
+    const mod = await import("../src/widgets/trust-policy");
+
+    await expect(mod.fetchTrustPolicy()).rejects.toThrow("Failed to fetch trust policy: 500 Server Error");
+  });
+
+  it("throws on invalid policy format", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: 1 }),
+    } as Response);
+
+    vi.resetModules();
+    const mod = await import("../src/widgets/trust-policy");
+
+    await expect(mod.fetchTrustPolicy()).rejects.toThrow("Invalid trust policy format");
+  });
+
+  it("supports URL override for fetchTrustPolicy", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockPolicy,
+    } as Response);
+
+    vi.resetModules();
+    const mod = await import("../src/widgets/trust-policy");
+
+    await mod.fetchTrustPolicy("https://custom.example/policy");
+    expect(globalThis.fetch).toHaveBeenCalledWith("https://custom.example/policy");
+  });
+
+  it("re-fetches policy after cache TTL expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T00:00:00Z"));
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockPolicy,
+    } as Response);
+
+    vi.resetModules();
+    const mod = await import("../src/widgets/trust-policy");
+
+    await mod.fetchTrustPolicy();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    // CACHE_TTL_MS is 5 minutes; move beyond it to force a re-fetch.
+    vi.setSystemTime(new Date("2026-04-15T00:06:00Z"));
+    await mod.fetchTrustPolicy();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("extractAllowlists returns deduplicated contracts and schemas", async () => {
+    vi.resetModules();
+    const mod = await import("../src/widgets/trust-policy");
+
+    const lists = mod.extractAllowlists(mockPolicy);
+    expect(lists.allowedContracts).toEqual(["0x1234567890abcdef1234567890abcdef12345678"]);
+    expect(lists.allowedSchemas).toEqual([
+      `0x${"a".repeat(64)}`,
+      `0x${"b".repeat(64)}`,
+      `0x${"c".repeat(64)}`,
+    ]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,12 +13,6 @@ export default defineConfig({
         "**/*.browser.ts",
         "**/*.d.ts",
         "**/types.ts",
-        // TEMPORARY: widgets module uses browser APIs (window, postMessage,
-        // HTMLIFrameElement) that require jsdom test environment.
-        // Tests to be added by test engineer — see omatrust-docs issue #4.
-        // Remove this exclusion once widget module tests are in place.
-        // Added: 2026-04-14 by @atom
-        "src/widgets/**",
       ],
       thresholds: {
         statements: 97,


### PR DESCRIPTION
## Summary
- add jsdom-based test coverage for `src/widgets/bridge.ts`, including handshake, origin/source validation, EAS validation paths, remount handling, and concurrent request correlation
- add trust-policy tests for fetch failures, cache behavior, TTL refresh, and allowlist extraction, plus protocol/index coverage tests
- remove the temporary `src/widgets/**` coverage exclusion in `vitest.config.ts` and add `jsdom` dev dependency for per-file jsdom environments

## Test plan
- [x] Run `npm test`
- [x] Verify global coverage thresholds pass (97% statements, 94% branches, 98% functions, 97% lines)
- [x] Confirm widget module tests run under jsdom and pass