### PR TITLE
feat: bump multiformats to v14 and split identity into ethers-free subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 Framework-agnostic TypeScript SDK for OMATrust.
 
-Current npm state:
-- As of February 25, 2026:
-  - `latest` -> `0.1.0-alpha.5`
-  - `alpha` -> `0.1.0-alpha.5`
 - Scope: `@oma3/omatrust`
 
 ## Install
@@ -25,7 +21,7 @@ npm install @oma3/omatrust@alpha ethers
 If you want to pin an exact version:
 
 ```bash
-npm install @oma3/omatrust@0.1.0-alpha.5 ethers
+npm install @oma3/omatrust@0.1.0-alpha.14 ethers
 ```
 
 If you use the reputation module, also install EAS SDK:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "canonicalize": "^2.1.0",
         "jose": "^6.2.3",
-        "multiformats": "^13.4.2"
+        "multiformats": "^14.0.0"
       },
       "devDependencies": {
         "@ethereum-attestation-service/eas-sdk": "^2.9.0",
@@ -5797,9 +5797,9 @@
       "license": "MIT"
     },
     "node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/mz": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oma3/omatrust",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-alpha.14",
   "description": "Framework-agnostic TypeScript SDK for OMATrust",
   "license": "MIT",
   "type": "module",
@@ -23,6 +23,14 @@
       },
       "import": "./dist/identity/index.js",
       "require": "./dist/identity/index.cjs"
+    },
+    "./identity/did": {
+      "types": {
+        "import": "./dist/identity/did-core.d.ts",
+        "require": "./dist/identity/did-core.d.cts"
+      },
+      "import": "./dist/identity/did-core.js",
+      "require": "./dist/identity/did-core.cjs"
     },
     "./reputation": {
       "types": {
@@ -71,7 +79,7 @@
   "dependencies": {
     "canonicalize": "^2.1.0",
     "jose": "^6.2.3",
-    "multiformats": "^13.4.2"
+    "multiformats": "^14.0.0"
   },
   "peerDependencies": {
     "@ethereum-attestation-service/eas-sdk": "^2.4.0",

--- a/src/identity/did-core.ts
+++ b/src/identity/did-core.ts
@@ -1,0 +1,335 @@
+/**
+ * Dependency-free DID utilities.
+ *
+ * This module contains pure string-based DID parsing, normalization, and
+ * construction functions that do NOT depend on ethers or any heavy runtime.
+ *
+ * Consumers who only need normalization / parsing (e.g. the MPAS Credential
+ * Adapter) can import from "@oma3/omatrust/identity/did" to avoid pulling
+ * in ethers (18 MB).
+ *
+ * For hashing and address derivation, import from "@oma3/omatrust/identity"
+ * which re-exports everything including the ethers-dependent functions.
+ */
+
+import { base64url } from "jose";
+import { OmaTrustError } from "../shared/errors";
+import { assertString } from "../shared/assert";
+import { parseCaip10 } from "./caip";
+import { validatePublicJwk } from "./jwk";
+
+export type Hex = `0x${string}`;
+export type Did = string;
+
+const DID_REGEX = /^did:[a-z0-9]+:.+$/i;
+
+export function isValidDid(did: string): boolean {
+  return DID_REGEX.test(did);
+}
+
+export function extractDidMethod(did: Did): string | null {
+  const match = did.match(/^did:([a-z0-9]+):/i);
+  return match ? match[1] : null;
+}
+
+export function extractDidIdentifier(did: Did): string | null {
+  const match = did.match(/^did:[a-z0-9]+:(.+)$/i);
+  return match ? match[1] : null;
+}
+
+export function normalizeDomain(domain: string): string {
+  assertString(domain, "domain", "INVALID_DID");
+  return domain.trim().toLowerCase().replace(/\.$/, "").replace(/^www\./, "");
+}
+
+export function normalizeDidWeb(input: string): Did {
+  assertString(input, "input", "INVALID_DID");
+  const trimmed = input.trim();
+
+  if (trimmed.startsWith("did:") && !trimmed.startsWith("did:web:")) {
+    throw new OmaTrustError("INVALID_DID", "Expected did:web DID", { input });
+  }
+
+  const identifier = trimmed.startsWith("did:web:")
+    ? trimmed.slice("did:web:".length)
+    : trimmed;
+
+  const [host, ...pathParts] = identifier.split("/");
+  if (!host) {
+    throw new OmaTrustError("INVALID_DID", "Invalid did:web identifier", { input });
+  }
+
+  const normalizedHost = normalizeDomain(host);
+  const path = pathParts.length > 0 ? `/${pathParts.join("/")}` : "";
+  return `did:web:${normalizedHost}${path}`;
+}
+
+export function normalizeDidPkh(input: string): Did {
+  assertString(input, "input", "INVALID_DID");
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("did:pkh:")) {
+    throw new OmaTrustError("INVALID_DID", "Expected did:pkh DID", { input });
+  }
+
+  const parts = trimmed.split(":");
+  if (parts.length !== 5) {
+    throw new OmaTrustError("INVALID_DID", "Invalid did:pkh format", { input });
+  }
+
+  const [, , namespace, chainId, address] = parts;
+  if (!namespace || !chainId || !address) {
+    throw new OmaTrustError("INVALID_DID", "Invalid did:pkh components", { input });
+  }
+
+  return `did:pkh:${namespace.toLowerCase()}:${chainId}:${address.toLowerCase()}`;
+}
+
+export function normalizeDidHandle(input: string): Did {
+  assertString(input, "input", "INVALID_DID");
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("did:handle:")) {
+    throw new OmaTrustError("INVALID_DID", "Expected did:handle DID", { input });
+  }
+
+  const parts = trimmed.split(":");
+  if (parts.length !== 4) {
+    throw new OmaTrustError("INVALID_DID", "Invalid did:handle format", { input });
+  }
+
+  const [, , platform, username] = parts;
+  if (!platform || !username) {
+    throw new OmaTrustError("INVALID_DID", "Invalid did:handle components", { input });
+  }
+
+  return `did:handle:${platform.toLowerCase()}:${username}`;
+}
+
+export function normalizeDidKey(input: string): Did {
+  assertString(input, "input", "INVALID_DID");
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("did:key:")) {
+    throw new OmaTrustError("INVALID_DID", "Expected did:key DID", { input });
+  }
+
+  return trimmed;
+}
+
+export function normalizeDid(input: string): Did {
+  assertString(input, "input", "INVALID_DID");
+  // Strip DID URL fragment (#...) — fragments are not part of the DID itself (W3C DID Core §3.5)
+  const trimmed = input.trim().split("#")[0];
+
+  if (!trimmed.startsWith("did:")) {
+    return normalizeDidWeb(trimmed);
+  }
+
+  if (!isValidDid(trimmed)) {
+    throw new OmaTrustError("INVALID_DID", "Invalid DID format", { input });
+  }
+
+  const method = extractDidMethod(trimmed);
+  switch (method) {
+    case "web":
+      return normalizeDidWeb(trimmed);
+    case "pkh":
+      return normalizeDidPkh(trimmed);
+    case "handle":
+      return normalizeDidHandle(trimmed);
+    case "key":
+      return normalizeDidKey(trimmed);
+    case "jwk":
+      return normalizeDidJwk(trimmed);
+    default:
+      return trimmed;
+  }
+}
+
+export function computeDidAddress(didHash: Hex): Hex {
+  assertString(didHash, "didHash", "INVALID_DID");
+  if (!/^0x[0-9a-fA-F]{64}$/.test(didHash)) {
+    throw new OmaTrustError("INVALID_DID", "didHash must be 32-byte hex", { didHash });
+  }
+
+  // Spec: low-order 160 bits of didHash, serialized as lowercase 0x-hex.
+  return `0x${didHash.slice(-40).toLowerCase()}` as Hex;
+}
+
+export function buildDidWeb(domain: string): Did {
+  return `did:web:${normalizeDomain(domain)}`;
+}
+
+export function buildDidPkh(
+  namespace: string,
+  chainId: string | number,
+  address: string
+): Did {
+  assertString(namespace, "namespace", "INVALID_DID");
+  assertString(address, "address", "INVALID_DID");
+  if (chainId === "" || chainId === null || chainId === undefined) {
+    throw new OmaTrustError("INVALID_DID", "chainId is required", { chainId });
+  }
+  return `did:pkh:${namespace.toLowerCase()}:${chainId}:${address.toLowerCase()}`;
+}
+
+export function buildEvmDidPkh(chainId: string | number, address: string): Did {
+  return buildDidPkh("eip155", chainId, address);
+}
+
+export function buildDidPkhFromCaip10(caip10: string): Did {
+  const parsed = parseCaip10(caip10);
+  return buildDidPkh(parsed.namespace, parsed.reference, parsed.address);
+}
+
+export function parseDidPkh(did: Did): { namespace: string; chainId: string; address: string } | null {
+  if (!did.startsWith("did:pkh:")) {
+    return null;
+  }
+
+  const parts = did.split(":");
+  if (parts.length !== 5) {
+    return null;
+  }
+
+  const [, , namespace, chainId, address] = parts;
+  if (!namespace || !chainId || !address) {
+    return null;
+  }
+
+  return { namespace, chainId, address };
+}
+
+export function getChainIdFromDidPkh(did: Did): string | null {
+  return parseDidPkh(did)?.chainId ?? null;
+}
+
+export function getAddressFromDidPkh(did: Did): string | null {
+  return parseDidPkh(did)?.address ?? null;
+}
+
+export function getNamespaceFromDidPkh(did: Did): string | null {
+  return parseDidPkh(did)?.namespace ?? null;
+}
+
+export function isEvmDidPkh(did: Did): boolean {
+  return getNamespaceFromDidPkh(did) === "eip155";
+}
+
+export function getDomainFromDidWeb(did: Did): string | null {
+  if (!did.startsWith("did:web:")) {
+    return null;
+  }
+
+  const identifier = did.slice("did:web:".length);
+  const [domain] = identifier.split("/");
+  return domain || null;
+}
+
+// ---------------------------------------------------------------------------
+// did:jwk normalization (depends on jose, not ethers)
+// ---------------------------------------------------------------------------
+
+// Base64url character set (no padding required)
+const BASE64URL_REGEX = /^[A-Za-z0-9_-]+$/;
+
+const VALID_JWK_KTY = new Set(["EC", "OKP", "RSA"]);
+
+/**
+ * Validate a did:jwk DID.
+ *
+ * Format: did:jwk:<base64url-encoded-JWK>
+ * - Must have exactly 3 colon-separated parts
+ * - Identifier must be valid base64url
+ * - Decoded value must be valid JSON
+ * - Decoded JSON must contain a valid kty field (EC, OKP, RSA)
+ * - Must NOT contain d (private key component)
+ */
+function validateDidJwk(did: string): { valid: boolean; method: "jwk"; error?: string } {
+  const parts = did.split(":");
+  if (parts.length !== 3) {
+    return {
+      valid: false,
+      method: "jwk",
+      error: `did:jwk must have exactly 3 colon-separated parts, got ${parts.length}`
+    };
+  }
+
+  const [, , encoded] = parts;
+
+  if (!encoded || encoded.length === 0) {
+    return { valid: false, method: "jwk", error: "Missing base64url-encoded JWK identifier" };
+  }
+
+  if (!BASE64URL_REGEX.test(encoded)) {
+    return {
+      valid: false,
+      method: "jwk",
+      error: "Identifier contains invalid base64url characters"
+    };
+  }
+
+  // Decode base64url to JSON
+  let decoded: string;
+  try {
+    const bytes = base64url.decode(encoded);
+    decoded = new TextDecoder().decode(bytes);
+  } catch {
+    return { valid: false, method: "jwk", error: "Failed to base64url-decode identifier" };
+  }
+
+  let jwk: Record<string, unknown>;
+  try {
+    jwk = JSON.parse(decoded);
+  } catch {
+    return { valid: false, method: "jwk", error: "Decoded identifier is not valid JSON" };
+  }
+
+  if (!jwk || typeof jwk !== "object" || Array.isArray(jwk)) {
+    return { valid: false, method: "jwk", error: "Decoded JWK must be a JSON object" };
+  }
+
+  // Must have kty
+  const kty = jwk.kty;
+  if (typeof kty !== "string" || !VALID_JWK_KTY.has(kty)) {
+    return {
+      valid: false,
+      method: "jwk",
+      error: `Invalid or missing kty field (must be one of: EC, OKP, RSA)`
+    };
+  }
+
+  // Must NOT contain private key material
+  if ("d" in jwk) {
+    return {
+      valid: false,
+      method: "jwk",
+      error: "DID must reference a public key — private key component (d) is not allowed"
+    };
+  }
+
+  // Validate required public key fields per kty (crv/x/y for EC, crv/x for OKP, n/e for RSA)
+  const jwkValidation = validatePublicJwk(jwk);
+  if (!jwkValidation.valid) {
+    return { valid: false, method: "jwk", error: jwkValidation.error };
+  }
+
+  return { valid: true, method: "jwk" };
+}
+
+/**
+ * Normalize a did:jwk DID.
+ * Validates structure and returns the DID unchanged (did:jwk is already canonical).
+ */
+export function normalizeDidJwk(input: string): Did {
+  assertString(input, "input", "INVALID_DID");
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("did:jwk:")) {
+    throw new OmaTrustError("INVALID_DID", "Expected did:jwk DID", { input });
+  }
+
+  const result = validateDidJwk(trimmed);
+  if (!result.valid) {
+    throw new OmaTrustError("INVALID_DID", result.error ?? "Invalid did:jwk", { input });
+  }
+
+  return trimmed;
+}

--- a/src/identity/did.ts
+++ b/src/identity/did.ts
@@ -1,3 +1,13 @@
+/**
+ * DID utilities — full surface including ethers-dependent hashing/address functions.
+ *
+ * Re-exports everything from ./did-pure (dependency-free) plus the ethers-dependent
+ * functions for hashing DDOs, deriving addresses, and deep EVM validation.
+ *
+ * If you only need normalization/parsing and want to avoid pulling in ethers,
+ * import from "@oma3/omatrust/identity/did" instead.
+ */
+
 import { getAddress, isAddress, keccak256, toUtf8Bytes } from "ethers";
 import { base64url } from "jose";
 import { OmaTrustError } from "../shared/errors";
@@ -5,145 +15,28 @@ import { assertString } from "../shared/assert";
 import { parseCaip10 } from "./caip";
 import { validatePublicJwk } from "./jwk";
 
-export type Hex = `0x${string}`;
-export type Did = string;
+// Import what we need from did-pure for internal use
+import {
+  type Hex,
+  type Did,
+  normalizeDid,
+  normalizeDidPkh,
+  extractDidMethod,
+  parseDidPkh,
+  isValidDid,
+  computeDidAddress,
+} from "./did-core";
 
-const DID_REGEX = /^did:[a-z0-9]+:.+$/i;
+// Re-export everything from the dependency-free module
+export * from "./did-core";
 
-export function isValidDid(did: string): boolean {
-  return DID_REGEX.test(did);
-}
-
-export function extractDidMethod(did: Did): string | null {
-  const match = did.match(/^did:([a-z0-9]+):/i);
-  return match ? match[1] : null;
-}
-
-export function extractDidIdentifier(did: Did): string | null {
-  const match = did.match(/^did:[a-z0-9]+:(.+)$/i);
-  return match ? match[1] : null;
-}
-
-export function normalizeDomain(domain: string): string {
-  assertString(domain, "domain", "INVALID_DID");
-  return domain.trim().toLowerCase().replace(/\.$/, "").replace(/^www\./, "");
-}
-
-export function normalizeDidWeb(input: string): Did {
-  assertString(input, "input", "INVALID_DID");
-  const trimmed = input.trim();
-
-  if (trimmed.startsWith("did:") && !trimmed.startsWith("did:web:")) {
-    throw new OmaTrustError("INVALID_DID", "Expected did:web DID", { input });
-  }
-
-  const identifier = trimmed.startsWith("did:web:")
-    ? trimmed.slice("did:web:".length)
-    : trimmed;
-
-  const [host, ...pathParts] = identifier.split("/");
-  if (!host) {
-    throw new OmaTrustError("INVALID_DID", "Invalid did:web identifier", { input });
-  }
-
-  const normalizedHost = normalizeDomain(host);
-  const path = pathParts.length > 0 ? `/${pathParts.join("/")}` : "";
-  return `did:web:${normalizedHost}${path}`;
-}
-
-export function normalizeDidPkh(input: string): Did {
-  assertString(input, "input", "INVALID_DID");
-  const trimmed = input.trim();
-  if (!trimmed.startsWith("did:pkh:")) {
-    throw new OmaTrustError("INVALID_DID", "Expected did:pkh DID", { input });
-  }
-
-  const parts = trimmed.split(":");
-  if (parts.length !== 5) {
-    throw new OmaTrustError("INVALID_DID", "Invalid did:pkh format", { input });
-  }
-
-  const [, , namespace, chainId, address] = parts;
-  if (!namespace || !chainId || !address) {
-    throw new OmaTrustError("INVALID_DID", "Invalid did:pkh components", { input });
-  }
-
-  return `did:pkh:${namespace.toLowerCase()}:${chainId}:${address.toLowerCase()}`;
-}
-
-export function normalizeDidHandle(input: string): Did {
-  assertString(input, "input", "INVALID_DID");
-  const trimmed = input.trim();
-  if (!trimmed.startsWith("did:handle:")) {
-    throw new OmaTrustError("INVALID_DID", "Expected did:handle DID", { input });
-  }
-
-  const parts = trimmed.split(":");
-  if (parts.length !== 4) {
-    throw new OmaTrustError("INVALID_DID", "Invalid did:handle format", { input });
-  }
-
-  const [, , platform, username] = parts;
-  if (!platform || !username) {
-    throw new OmaTrustError("INVALID_DID", "Invalid did:handle components", { input });
-  }
-
-  return `did:handle:${platform.toLowerCase()}:${username}`;
-}
-
-export function normalizeDidKey(input: string): Did {
-  assertString(input, "input", "INVALID_DID");
-  const trimmed = input.trim();
-  if (!trimmed.startsWith("did:key:")) {
-    throw new OmaTrustError("INVALID_DID", "Expected did:key DID", { input });
-  }
-
-  return trimmed;
-}
-
-export function normalizeDid(input: string): Did {
-  assertString(input, "input", "INVALID_DID");
-  // Strip DID URL fragment (#...) — fragments are not part of the DID itself (W3C DID Core §3.5)
-  const trimmed = input.trim().split("#")[0];
-
-  if (!trimmed.startsWith("did:")) {
-    return normalizeDidWeb(trimmed);
-  }
-
-  if (!isValidDid(trimmed)) {
-    throw new OmaTrustError("INVALID_DID", "Invalid DID format", { input });
-  }
-
-  const method = extractDidMethod(trimmed);
-  switch (method) {
-    case "web":
-      return normalizeDidWeb(trimmed);
-    case "pkh":
-      return normalizeDidPkh(trimmed);
-    case "handle":
-      return normalizeDidHandle(trimmed);
-    case "key":
-      return normalizeDidKey(trimmed);
-    case "jwk":
-      return normalizeDidJwk(trimmed);
-    default:
-      return trimmed;
-  }
-}
+// ---------------------------------------------------------------------------
+// Ethers-dependent: Hashing and address derivation
+// ---------------------------------------------------------------------------
 
 export function computeDidHash(did: Did): Hex {
   const normalized = normalizeDid(did);
   return keccak256(toUtf8Bytes(normalized)) as Hex;
-}
-
-export function computeDidAddress(didHash: Hex): Hex {
-  assertString(didHash, "didHash", "INVALID_DID");
-  if (!/^0x[0-9a-fA-F]{64}$/.test(didHash)) {
-    throw new OmaTrustError("INVALID_DID", "didHash must be 32-byte hex", { didHash });
-  }
-
-  // Spec: low-order 160 bits of didHash, serialized as lowercase 0x-hex.
-  return `0x${didHash.slice(-40).toLowerCase()}` as Hex;
 }
 
 export function didToAddress(did: Did): Hex {
@@ -158,75 +51,9 @@ export function validateDidAddress(did: Did, address: Hex): boolean {
   }
 }
 
-export function buildDidWeb(domain: string): Did {
-  return `did:web:${normalizeDomain(domain)}`;
-}
-
-export function buildDidPkh(
-  namespace: string,
-  chainId: string | number,
-  address: string
-): Did {
-  assertString(namespace, "namespace", "INVALID_DID");
-  assertString(address, "address", "INVALID_DID");
-  if (chainId === "" || chainId === null || chainId === undefined) {
-    throw new OmaTrustError("INVALID_DID", "chainId is required", { chainId });
-  }
-  return `did:pkh:${namespace.toLowerCase()}:${chainId}:${address.toLowerCase()}`;
-}
-
-export function buildEvmDidPkh(chainId: string | number, address: string): Did {
-  return buildDidPkh("eip155", chainId, address);
-}
-
-export function buildDidPkhFromCaip10(caip10: string): Did {
-  const parsed = parseCaip10(caip10);
-  return buildDidPkh(parsed.namespace, parsed.reference, parsed.address);
-}
-
-function parseDidPkh(did: Did): { namespace: string; chainId: string; address: string } | null {
-  if (!did.startsWith("did:pkh:")) {
-    return null;
-  }
-
-  const parts = did.split(":");
-  if (parts.length !== 5) {
-    return null;
-  }
-
-  const [, , namespace, chainId, address] = parts;
-  if (!namespace || !chainId || !address) {
-    return null;
-  }
-
-  return { namespace, chainId, address };
-}
-
-export function getChainIdFromDidPkh(did: Did): string | null {
-  return parseDidPkh(did)?.chainId ?? null;
-}
-
-export function getAddressFromDidPkh(did: Did): string | null {
-  return parseDidPkh(did)?.address ?? null;
-}
-
-export function getNamespaceFromDidPkh(did: Did): string | null {
-  return parseDidPkh(did)?.namespace ?? null;
-}
-
-export function isEvmDidPkh(did: Did): boolean {
-  return getNamespaceFromDidPkh(did) === "eip155";
-}
-
-export function getDomainFromDidWeb(did: Did): string | null {
-  if (!did.startsWith("did:web:")) {
-    return null;
-  }
-
-  const identifier = did.slice("did:web:".length);
-  const [domain] = identifier.split("/");
-  return domain || null;
-}
+// ---------------------------------------------------------------------------
+// Ethers-dependent: Address extraction
+// ---------------------------------------------------------------------------
 
 /**
  * Extract an EVM address from a DID or address-like identifier.
@@ -278,7 +105,7 @@ export function extractAddressFromDid(identifier: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Private-Key DID Validation
+// Ethers-dependent: Private-Key DID Validation
 // ---------------------------------------------------------------------------
 
 /** Result of private-key DID validation */
@@ -337,15 +164,7 @@ export function validatePrivateKeyDid(did: string): PrivateKeyDidValidation {
 }
 
 /**
- * Validate a did:pkh DID.
- *
- * Format: did:pkh:<namespace>:<chainId>:<address>
- * - Must have exactly 5 colon-separated parts
- * - namespace must be a valid CAIP-2 namespace (lowercase alphanumeric + hyphens, 3-8 chars)
- * - chainId must be non-empty
- * - address must be non-empty
- * - For eip155 namespace: address must be a valid EVM address (0x + 40 hex chars)
- * - For other namespaces: address must be non-empty (permissive fallback)
+ * Validate a did:pkh DID with deep EVM address validation.
  */
 function validateDidPkh(did: string): PrivateKeyDidValidation {
   const parts = did.split(":");
@@ -416,14 +235,7 @@ function validateDidPkh(did: string): PrivateKeyDidValidation {
 }
 
 /**
- * Validate a did:jwk DID.
- *
- * Format: did:jwk:<base64url-encoded-JWK>
- * - Must have exactly 3 colon-separated parts
- * - Identifier must be valid base64url
- * - Decoded value must be valid JSON
- * - Decoded JSON must contain a valid kty field (EC, OKP, RSA)
- * - Must NOT contain d (private key component)
+ * Validate a did:jwk DID (duplicated here for PrivateKeyDidValidation return type).
  */
 function validateDidJwk(did: string): PrivateKeyDidValidation {
   const parts = did.split(":");
@@ -495,23 +307,4 @@ function validateDidJwk(did: string): PrivateKeyDidValidation {
   }
 
   return { valid: true, method: "jwk" };
-}
-
-/**
- * Normalize a did:jwk DID.
- * Validates structure and returns the DID unchanged (did:jwk is already canonical).
- */
-export function normalizeDidJwk(input: string): Did {
-  assertString(input, "input", "INVALID_DID");
-  const trimmed = input.trim();
-  if (!trimmed.startsWith("did:jwk:")) {
-    throw new OmaTrustError("INVALID_DID", "Expected did:jwk DID", { input });
-  }
-
-  const result = validateDidJwk(trimmed);
-  if (!result.valid) {
-    throw new OmaTrustError("INVALID_DID", result.error ?? "Invalid did:jwk", { input });
-  }
-
-  return trimmed;
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: [
     "src/index.ts",
     "src/identity/index.ts",
+    "src/identity/did-core.ts",
     "src/reputation/index.ts",
     "src/reputation/index.browser.ts",
     "src/app-registry/index.ts",


### PR DESCRIPTION
## Risk Level

**Risk:** medium

## Summary

- Upgrade multiformats from ^13.4.2 to ^14.0.0, fixing CJS subpath exports
- Extract dependency-free DID functions into src/identity/did-core.ts and expose as @oma3/omatrust/identity/did to address Issue #41
- Also closes Issue #33

## Testing Performed

Full automated on this repo and on maps and rep-attestation-frontend

## CI Status

- [ ] All required checks pass

